### PR TITLE
require node 16 due to adapter-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,6 @@
   },
   "readmeFilename": "README.md",
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   }
 }


### PR DESCRIPTION
adapter-core 3.x.x is kn own to fail when installed at node 14 or earlier. So this adapter requires node 16 minimum